### PR TITLE
Fix Default Value Assign to Star

### DIFF
--- a/StarViewController/StarRateView.swift
+++ b/StarViewController/StarRateView.swift
@@ -8,47 +8,56 @@
 
 import Foundation
 import UIKit
+
 protocol RatingViewDelegate {
     func updateRatingFormatValue(_ value: Int)
 }
+
 @IBDesignable
 class StarRateView: UIView {
+    
     // MARK: - Properties
     var imageViewList = [UIImageView]()
-    var rating = 0.0
     var delegate: RatingViewDelegate!
+    
     @IBInspectable
     var maxCount: Int = 5 {
         didSet {
             updateView()
         }
     }
+    
     @IBInspectable
     var fillImage: UIImage = UIImage(named: "shapeFill.png")! {
         didSet {
-             updateView()
+            updateView()
         }
     }
+    
     @IBInspectable
     var emptyImage: UIImage = UIImage(named: "shapeEmpty.png")! {
         didSet {
             updateView()
         }
     }
+    
     @IBInspectable
     var ratingValue: Int = -1 {
         didSet {
-             updateViewAppearance(ratingValue)
+            updateViewAppearance(ratingValue)
         }
     }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         updateView()
     }
+    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         updateView()
     }
+    
     // MAKR: - View
     func updateView() {
         imageViewList.removeAll()
@@ -62,6 +71,7 @@ class StarRateView: UIView {
             imageView.contentMode = .scaleAspectFit
             imageViewList.append(imageView)
         }
+        
         //Create UIStackView
         let stackView = UIStackView(arrangedSubviews: imageViewList)
         stackView.alignment = .fill
@@ -69,6 +79,7 @@ class StarRateView: UIView {
         stackView.distribution = .fillEqually
         stackView.spacing = 5.0
         addSubview(stackView)
+        
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
         stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
@@ -80,11 +91,16 @@ class StarRateView: UIView {
         var tag = 0
         for imageView in imageViewList {
             let imageViewX = Int(imageView.frame.origin.x)
-            print("imageViewX = ",imageViewX)
+            // print("imageViewX = ",imageViewX)
             if xPoint > imageViewX {
-                imageView.image = fillImage
-                setNeedsDisplay()
-                tag = tag + 1
+                if xPoint == tag {
+                    imageView.image = emptyImage
+                    setNeedsDisplay()
+                } else {
+                    imageView.image = fillImage
+                    tag = tag + 1
+                    setNeedsDisplay()
+                }
             } else {
                 imageView.image = emptyImage
                 setNeedsDisplay()
@@ -92,6 +108,7 @@ class StarRateView: UIView {
         }
         updateRating(tag)
     }
+    
     // MARK: - UITouch Delegate
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         if let touch = touches.first {
@@ -99,18 +116,21 @@ class StarRateView: UIView {
             updateViewAppearance(Int(currentPoint.x))
         }
     }
+    
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
         if let touch = touches.first {
             let currentPoint = touch.location(in: self)
             updateViewAppearance(Int(currentPoint.x))
         }
     }
+    
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         if let touch = touches.first {
             let currentPoint = touch.location(in: self)
             updateViewAppearance(Int(currentPoint.x))
         }
     }
+    
     //MARK: - Delegate
     func updateRating(_ value: Int) {
         if delegate != nil {
@@ -118,3 +138,5 @@ class StarRateView: UIView {
         }
     }
 }
+
+

--- a/StarViewController/ViewController.swift
+++ b/StarViewController/ViewController.swift
@@ -18,7 +18,7 @@ class ViewController: UIViewController {
     }
     func setupRatingView() {
         starRateView.delegate = self
-        starRateView.ratingValue = -1
+        starRateView.ratingValue = 4
     }
 
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
Fixed initial rating of star rating values

when we assign value `starRatingView.ratingValue = 2`, the star automatically fill 2 star
